### PR TITLE
update config_standard_storage.yaml for a persistent link to report issues

### DIFF
--- a/config_standard_storage.yaml
+++ b/config_standard_storage.yaml
@@ -1,5 +1,5 @@
 hub:
-  templateVars: {'announcement_spawn': 'In case of error, please <a href="https://github.com/det-lab/jupyterhub-deploy-kubernetes-jetstream/issues/new">open an issue on Github</a> pasting the entire error message'}
+  templateVars: {'announcement': 'In case of error, please <a href="https://github.com/det-lab/jupyterhub-deploy-kubernetes-jetstream/issues/new">open an issue on Github</a> pasting the entire error message'}
   db:
     type: sqlite-pvc
     pvc:


### PR DESCRIPTION
Right now info about how to report issues is "hidden" in Confluence documentation that's only visible to collaboration members who know how to look for it.  Adding a banner for the full login and spawn process would help, I think.